### PR TITLE
Combine dropColumn calls in up migration

### DIFF
--- a/src/migrations/2021_09_22_105532_remove_non_translated_columns_on_metadata_table.php
+++ b/src/migrations/2021_09_22_105532_remove_non_translated_columns_on_metadata_table.php
@@ -14,11 +14,7 @@ class RemoveNonTranslatedColumnsOnMetadataTable extends Migration
     public function up()
     {
         Schema::table('metadata', function(Blueprint $table){
-            $table->dropColumn('title');
-            $table->dropColumn('description');
-            $table->dropColumn('og_title');
-            $table->dropColumn('og_description');
-            $table->dropColumn('canonical_url');
+            $table->dropColumn(['title', 'description', 'og_title', 'og_description', 'canonical_url']);
         });
     }
 


### PR DESCRIPTION
Hi CWS Digital,

I was working on some feature tests for an application using `twill-metadata` and got the following error while running the migrations on SQLite:

```
BadMethodCallException: SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.

/var/www/html/vendor/laravel/framework/src/Illuminate/Database/Schema/Blueprint.php:156
/var/www/html/vendor/laravel/framework/src/Illuminate/Database/Schema/Blueprint.php:129
/var/www/html/vendor/laravel/framework/src/Illuminate/Database/Schema/Blueprint.php:108
/var/www/html/vendor/laravel/framework/src/Illuminate/Database/Schema/Builder.php:364
/var/www/html/vendor/laravel/framework/src/Illuminate/Database/Schema/Builder.php:211
/var/www/html/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:261
/var/www/html/vendor/cwsdigital/twill-metadata/src/migrations/2021_09_22_105532_remove_non_translated_columns_on_metadata_table.php:22
...
```

I was not aware of this limitation with SQLite, but it seems to be a known issue in the Laravel community. I was able to find a quick workaround in this GitHub issue: https://github.com/laravel/framework/issues/2979#issuecomment-227468621

Combining all column names into a single `dropColumn()` call works beautifully.

Let me know if I can provide any more information.