### PR TITLE
update readme me to change default route params

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ return [
     'settings' => [
         'title' => 'Settings',
         'route' => 'admin.settings',
-        'params' => ['section' => 'general'],
+        'params' => ['section' => 'seo'],
         'primary_navigation' => [
             //...
             'seo' => [


### PR DESCRIPTION
If there is no _general_ tab under settings, the settings menu won't work, so maybe it should link to the _SEO_ tab by default.