### PR TITLE
Depend on abstractions in the repository behaviour

### DIFF
--- a/src/Models/Behaviours/HasMetadata.php
+++ b/src/Models/Behaviours/HasMetadata.php
@@ -3,6 +3,9 @@
 namespace CwsDigital\TwillMetadata\Models\Behaviours;
 
 use A17\Twill\Facades\TwillAppSettings;
+use A17\Twill\Models\Behaviors\HasBlocks;
+use A17\Twill\Models\Behaviors\HasMedias;
+use CwsDigital\TwillMetadata\Models\Metadata;
 
 trait HasMetadata
 {
@@ -10,7 +13,7 @@ trait HasMetadata
 
     public function metadata()
     {
-        return $this->morphOne('CwsDigital\TwillMetadata\Models\Metadata', 'meta_describable');
+        return $this->morphOne(Metadata::class, 'meta_describable');
     }
 
     public function getSocialImageAttribute()
@@ -22,9 +25,9 @@ trait HasMetadata
         } elseif ($this->hasAnyImages()) {
             return $this->getDefaultMetadataFallbackImage();
         } else {
-            $hasMediaImage = TwillAppSettings::getGroupDataForSectionAndName('seo','metadata')->hasImage('default_social_image', 'default');
+            $hasMediaImage = TwillAppSettings::getGroupDataForSectionAndName('seo', 'metadata')->hasImage('default_social_image', 'default');
             if ($hasMediaImage) {
-                return TwillAppSettings::getGroupDataForSectionAndName('seo','metadata')->image('default_social_image', 'default');
+                return TwillAppSettings::getGroupDataForSectionAndName('seo', 'metadata')->image('default_social_image', 'default');
             }
         }
     }
@@ -33,10 +36,10 @@ trait HasMetadata
     {
         if (array_key_exists($key, $this->metadataFallbacks)) {
             return
-                ! empty($this->metadataFallbacks[$key]) &&
-                is_array($this->metadataFallbacks[$key]) &&
-                array_key_exists('role', $this->metadataFallbacks[$key]) &&
-                array_key_exists('crop', $this->metadataFallbacks[$key]);
+                ! empty($this->metadataFallbacks[$key])
+                && is_array($this->metadataFallbacks[$key])
+                && array_key_exists('role', $this->metadataFallbacks[$key])
+                && array_key_exists('crop', $this->metadataFallbacks[$key]);
         } else {
             return false;
         }
@@ -90,14 +93,14 @@ trait HasMetadata
 
     public function hasAnyMedias()
     {
-        $hasMedias = $this->usesTrait('A17\Twill\Models\Behaviors\HasMedias');
+        $hasMedias = $this->usesTrait(HasMedias::class);
 
         return $hasMedias ? $this->medias()->count() : 0;
     }
 
     public function hasAnyBlockMedias()
     {
-        $hasBlocks = $this->usesTrait('A17\Twill\Models\Behaviors\HasBlocks');
+        $hasBlocks = $this->usesTrait(HasBlocks::class);
 
         return $hasBlocks ? $this->blocks()->has('medias')->count() : 0;
     }

--- a/src/Repositories/Behaviours/HandleMetadata.php
+++ b/src/Repositories/Behaviours/HandleMetadata.php
@@ -2,26 +2,26 @@
 
 namespace CwsDigital\TwillMetadata\Repositories\Behaviours;
 
-use A17\Twill\Models\Model;
+use A17\Twill\Models\Contracts\TwillModelContract;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 
 trait HandleMetadata
 {
     // Prefix for metadata fields in form
-    protected $metadataFieldPrefix = 'metadata';
+    protected string $metadataFieldPrefix = 'metadata';
 
     // Fields with fixed default values that we want persisting to store if blank
     // N.B. this does not include those fields that fallback to another field when blank
-    protected $withDefaultValues = ['card_type', 'og_type'];
+    protected array $withDefaultValues = ['card_type', 'og_type'];
 
     /**
-     * Handle saving of metadata fields from form submission
+     * Handle saving of metadata fields from form submission.
      *
-     * @param  Model  $object
-     * @param  array  $fields
+     * @param \A17\Twill\Models\Contracts\TwillModelContract $object
+     * @param array                                          $fields
      */
-    public function afterSaveHandleMetadata(Model $object, array $fields)
+    public function afterSaveHandleMetadata(TwillModelContract $object, array $fields)
     {
         // Due to the way twill handles adding data to VueX store
         // metadata will come through in individual fields metadata[title]... not in an array
@@ -37,15 +37,16 @@ trait HandleMetadata
     }
 
     /**
-     * Prepares the metadata fields for the admin form view
+     * Prepares the metadata fields for the admin form view.
      *
-     * @param  Model  $object
-     * @param  array  $fields
+     * @param \A17\Twill\Models\Contracts\TwillModelContract $object
+     * @param array                                          $fields
+     *
      * @return array
      */
-    public function getFormFieldsHandleMetadata(Model $object, array $fields)
+    public function getFormFieldsHandleMetadata(TwillModelContract $object, array $fields)
     {
-        //If the metadata object doesn't exist create it.  Every 'meta_describable' will need one entry.
+        // If the metadata object doesn't exist create it.  Every 'meta_describable' will need one entry.
         $metadata = $object->metadata ?? $object->metadata()->create();
 
         $metadata = $this->setFieldDefaults($object, $metadata);
@@ -66,9 +67,10 @@ trait HandleMetadata
 
     /**
      * Filters the full fields array down to just the metadata fields
-     * removes the field prefix and sets the keys correctly for persisting to store
+     * removes the field prefix and sets the keys correctly for persisting to store.
      *
-     * @param  array  $fields
+     * @param array $fields
+     *
      * @return array
      */
     protected function getMetadataFields(array $fields)
@@ -86,13 +88,14 @@ trait HandleMetadata
     }
 
     /**
-     * Set default values on fields that require it
+     * Set default values on fields that require it.
      *
-     * @param  Model  $object
-     * @param  array  $fields
+     * @param \A17\Twill\Models\Contracts\TwillModelContract $object
+     * @param array                                          $fields
+     *
      * @return array
      */
-    protected function setFieldDefaults(Model $object, $fields)
+    protected function setFieldDefaults(TwillModelContract $object, $fields)
     {
         foreach ($this->withDefaultValues as $fieldName) {
             if (empty($fields[$fieldName])) {
@@ -105,11 +108,14 @@ trait HandleMetadata
     }
 
     /**
-     * @param $key
+     * Determine if the field belongs to the metadata.
+     *
+     * @param string $key
+     *
      * @return bool
      */
-    protected function isMetadataField($key)
+    protected function isMetadataField(string $key)
     {
-        return substr($key, 0, strlen($this->metadataFieldPrefix)) === $this->metadataFieldPrefix;
+        return Str::startsWith($key, $this->metadataFieldPrefix);
     }
 }


### PR DESCRIPTION
This PR updates the method signature in the repository behaviour to depend on the `\A17\Twill\Models\Contracts\TwillModelContract` abstraction instead of the concrete implementation. ie. `\A17\Twill\Models\Model`

This makes it easier to use metadata on objects which are not directly managed trough twill, but still serve as the basis for metadata and other related entities.

In addition I've made some small modifications to the usage of classes within the `HasMetadata` trait. These changes don't really change anything in the way PHP resolves these classes, but it primarily makes it simpler to click trough them in an IDE.