### PR TITLE
Force columns to be nullable, needed for Laravel 11

### DIFF
--- a/src/migrations/2021_09_21_114756_update_metadata_description_fields.php
+++ b/src/migrations/2021_09_21_114756_update_metadata_description_fields.php
@@ -14,26 +14,26 @@ class UpdateMetadataDescriptionFields extends Migration
     public function up()
     {
         Schema::table('metadata', function (Blueprint $table) {
-            $table->text('description')->change();
-            $table->text('og_description')->change();
+            $table->text('description')->nullable()->change();
+            $table->text('og_description')->nullable()->change();
         });
 
         Schema::table('metadata_translations', function (Blueprint $table) {
-            $table->text('description')->change();
-            $table->text('og_description')->change();
+            $table->text('description')->nullable()->change();
+            $table->text('og_description')->nullable()->change();
         });
     }
 
     public function down()
     {
         Schema::table('metadata', function (Blueprint $table) {
-            $table->string('description')->change();
-            $table->string('og_description')->change();
+            $table->string('description')->nullable()->change();
+            $table->string('og_description')->nullable()->change();
         });
 
         Schema::table('metadata_translations', function (Blueprint $table) {
-            $table->string('description')->change();
-            $table->string('og_description')->change();
+            $table->string('description')->nullable()->change();
+            $table->string('og_description')->nullable()->change();
         });
     }
 }


### PR DESCRIPTION
Because Laravel 11 dropped doctrine/dbal, we now have to explicitly do this on migrations. ¯\_(ツ)_/¯ 